### PR TITLE
fix(client): repair basePath URL construction prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .idea
 ###
 .private/
-external-dns-unifi-webhook
+webhook

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as builder
+FROM golang:1.22-alpine AS builder
 ARG PKG=github.com/crutonjohn/external-dns-opnsense-webhook
 ARG VERSION=dev
 ARG REVISION=dev

--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ This effecively protects your record from ownership conflicts while still allowi
 
 ---
 
+## 👷 Building & Testing
+
+Build:
+
+```sh
+go build -ldflags "-s -w -X main.Version=test -X main.Gitsha=test" ./cmd/webhook
+```
+
+Run:
+
+```sh
+OPNSENSE_HOST=https://192.168.0.1 OPNSENSE_API_SECRET=<secret value> OPNSENSE_API_KEY=<key value> ./webhook
+```
+
+---
+
 ## 🤝 Gratitude and Thanks
 
 Thanks to all the people who donate their time to the [Home Operations](https://discord.gg/home-operations) Discord community.

--- a/internal/opnsense-unbound/client.go
+++ b/internal/opnsense-unbound/client.go
@@ -31,7 +31,13 @@ func newOpnsenseClient(config *Config) (*httpClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse url: %w", err)
 	}
-	u.Path = path.Join(u.Path, "api/unbound")
+
+	// Ensure the base path is correctly set
+	basePath, err := url.Parse("api/unbound/")
+	if err != nil {
+		return nil, fmt.Errorf("parse base path: %w", err)
+	}
+	u = u.ResolveReference(basePath)
 
 	// Create the HTTP client
 	client := &httpClient{
@@ -98,6 +104,7 @@ func (c *httpClient) doRequest(method, path string, body io.Reader) (*http.Respo
 	log.Debugf("doRequest: response code from %s request to %s: %d", method, u, resp.StatusCode)
 
 	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
 		return nil, fmt.Errorf("doRequest: %s request to %s was not successful: %d", method, u, resp.StatusCode)
 	}
 


### PR DESCRIPTION
this fixes a regression introduced after https://github.com/crutonjohn/external-dns-opnsense-webhook/pull/5 was implemented.

should close https://github.com/crutonjohn/external-dns-opnsense-webhook/issues/24

additionally:
- build(dockerfile): smol lint fix
- docs(readme): add some context for testing
  - this is needed for me in the future cause i'll forget
- chore(gitignore): ignore testing artifact