### PR TITLE
fix: close response body in DeleteHostOverride to prevent memory leak

### DIFF
--- a/internal/opnsense-unbound/client.go
+++ b/internal/opnsense-unbound/client.go
@@ -197,13 +197,15 @@ func (c *httpClient) DeleteHostOverride(endpoint *endpoint.Endpoint) error {
 	log.Debugf("delete: Found match %s", lookup.Uuid)
 
 	log.Debugf("delete: Sending POST %s", lookup.Uuid)
-	if _, err = c.doRequest(
+	resp, err := c.doRequest(
 		http.MethodPost,
 		path.Join("settings/delHostOverride", lookup.Uuid),
 		strings.NewReader(emptyJSONObject),
-	); err != nil {
+	)
+	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return nil
 }


### PR DESCRIPTION
The DeleteHostOverride function was not closing the HTTP response body, causing memory to leak with each DNS record deletion. Over time, this accumulated to over 1GB of memory usage.

Added defer resp.Body.Close() to properly release resources after the HTTP request completes.

Fixes #15

Tested with `ghcr.io/billimek/external-dns-opnsense-webhook:memory-leak-fix-amd64`