### PR TITLE
feat: add TXT record support for OPNsense Unbound

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ This webhook graciously ~~stolen~~ inspired by [Kashall's Unifi Webhook](https:/
 
 ## 🗒️ Important Notes
 
-As of this writing this webhook only supports creating A records using Unbound's Host Overrides. Theoretically AAAA records should work without much (if any) modification. A/AAAA records work because they effectively map 1:1 with Host Overrides. With significantly more effort, CNAMEs could be supported and mapped to Host Override Aliases, which I may or may not implement.
+As of this writing this webhook supports A, AAAA, and TXT records using Unbound's Host Overrides. A/AAAA/TXT records work because they effectively map 1:1 with Host Overrides.
 
-Furthermore, due to lack of support for TXT records in OPNsense's Unbound API we cannot leverage external-dns' normal `registry` behavior. Using an external registry would be optimal but not required for this webhook to function. Without a valid registry there is no concept of DNS record "ownership". **This means that the webhook will assume ownership of all Host Overrides that match `domainFilters` in Unbound**. There is a DNS pattern that exists to overcome this limitation detailed below.
+With significantly more effort, CNAMEs could be supported and mapped to Host Override Aliases, which may be implemented in the future.
+
+> [!NOTE]
+> TXT record support requires OPNsense >= 25.7 or later versions with TXT record support in Unbound.
 
 ### Structuring Your Unbound Records
 

--- a/internal/opnsense-unbound/client.go
+++ b/internal/opnsense-unbound/client.go
@@ -112,7 +112,7 @@ func (c *httpClient) doRequest(method, path string, body io.Reader) (*http.Respo
 }
 
 // GetHostOverrides retrieves the list of HostOverrides from the Opnsense Firewall's Unbound API.
-// These are equivalent to A or AAAA records
+// These are equivalent to A, AAAA, or TXT records
 func (c *httpClient) GetHostOverrides() ([]DNSRecord, error) {
 	resp, err := c.doRequest(
 		http.MethodGet,
@@ -131,10 +131,13 @@ func (c *httpClient) GetHostOverrides() ([]DNSRecord, error) {
 
 	log.Debugf("gethost: retrieved records: %+v", records.Rows)
 
+	if records.Rows == nil {
+		return []DNSRecord{}, nil
+	}
 	return records.Rows, nil
 }
 
-// CreateHostOverride creates a new DNS A or AAAA record in the Opnsense Firewall's Unbound API.
+// CreateHostOverride creates a new DNS A, AAAA, or TXT record in the Opnsense Firewall's Unbound API.
 func (c *httpClient) CreateHostOverride(endpoint *endpoint.Endpoint) (*DNSRecord, error) {
 	log.Debugf("create: Try pulling pre-existing Unbound %s record: %s", endpoint.RecordType, endpoint.DNSName)
 	lookup, err := c.lookupHostOverrideIdentifier(endpoint.DNSName, endpoint.RecordType)
@@ -150,14 +153,22 @@ func (c *httpClient) CreateHostOverride(endpoint *endpoint.Endpoint) (*DNSRecord
 
 	splitHost := SplitUnboundFQDN(endpoint.DNSName)
 
+	record := DNSRecord{
+		Enabled:  "1",
+		Rr:       endpoint.RecordType,
+		Hostname: splitHost[0],
+		Domain:   splitHost[1],
+	}
+
+	if endpoint.RecordType == "TXT" {
+		record.TxtData = endpoint.Targets[0]
+	} else {
+		record.Server = endpoint.Targets[0]
+	}
+
 	jsonBody, err := json.Marshal(unboundAddHostOverride{
-		Host: DNSRecord{
-			Enabled:  "1",
-			Rr:       endpoint.RecordType,
-			Server:   endpoint.Targets[0],
-			Hostname: splitHost[0],
-			Domain:   splitHost[1],
-		}})
+		Host: record,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -177,11 +188,11 @@ func (c *httpClient) CreateHostOverride(endpoint *endpoint.Endpoint) (*DNSRecord
 	// {"result":"failed"}
 	//if resp.Body != nil && resp.Body
 
-	var record unboundAddHostOverride
-	if err = json.NewDecoder(resp.Body).Decode(&record); err != nil {
+	var respRecord unboundAddHostOverride
+	if err = json.NewDecoder(resp.Body).Decode(&respRecord); err != nil {
 		return nil, err
 	}
-	log.Debugf("create: created record: %+v", record)
+	log.Debugf("create: created record: %+v", respRecord)
 
 	return nil, nil
 }

--- a/internal/opnsense-unbound/provider.go
+++ b/internal/opnsense-unbound/provider.go
@@ -45,10 +45,19 @@ func (p *Provider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 
 	var endpoints []*endpoint.Endpoint
 	for _, record := range records {
+		var targets endpoint.Targets
+		recordType := PruneUnboundType(record.Rr)
+
+		if recordType == "TXT" {
+			targets = endpoint.NewTargets(record.TxtData)
+		} else {
+			targets = endpoint.NewTargets(record.Server)
+		}
+
 		ep := &endpoint.Endpoint{
 			DNSName:    JoinUnboundFQDN(record.Hostname, record.Domain),
-			RecordType: PruneUnboundType(record.Rr),
-			Targets:    endpoint.NewTargets(record.Server),
+			RecordType: recordType,
+			Targets:    targets,
 		}
 
 		if !p.domainFilter.Match(ep.DNSName) {

--- a/internal/opnsense-unbound/types.go
+++ b/internal/opnsense-unbound/types.go
@@ -15,10 +15,11 @@ type DNSRecord struct {
 	Hostname    string `json:"hostname"`
 	Domain      string `json:"domain"`
 	Rr          string `json:"rr"`
-	Server      string `json:"server"`
+	Server      string `json:"server,omitempty"`
 	Description string `json:"description,omitempty"`
 	Mx          string `json:"mx,omitempty"`
 	MxPrio      string `json:"mxprio,omitempty"`
+	TxtData     string `json:"txtdata,omitempty"`
 }
 
 // unboundRecordsList is the main item returned from the Opnsense Unbound API

--- a/internal/opnsense-unbound/utils.go
+++ b/internal/opnsense-unbound/utils.go
@@ -28,6 +28,8 @@ func EmbellishUnboundType(unboundType string) string {
 		return unboundType + " (IPv4 address)"
 	case "AAAA":
 		return unboundType + " (IPv6 address)"
+	case "TXT":
+		return unboundType + " (Text record)"
 	}
 	return unboundType
 }


### PR DESCRIPTION
## Summary
Add support for TXT records in OPNsense Unbound, enabling use with external-dns registry: txt mode.

## Changes
- Add TxtData field to DNSRecord struct for storing TXT record content
- Update CreateHostOverride to conditionally use TxtData for TXT records
- Update Records provider to read TxtData for TXT records  
- Handle null Rows response from API gracefully
- Add TXT case to EmbellishUnboundType utility function
- Update documentation to reflect TXT record support

## Testing
Tested with OPNsense 25.7+ API to verify:
- ✅ TXT record creation with `txtdata` field
- ✅ TXT record retrieval via searchHostOverride
- ✅ TXT record deletion

## Requirements
- OPNsense >= 25.7 with TXT record support in Unbound

## Closes
Related to TXT record support requested in OPNsense changelog 25.7.4