### PR TITLE
feat: add CNAME record support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This webhook graciously ~~stolen~~ inspired by [Kashall's Unifi Webhook](https:/
 
 As of this writing this webhook supports A, AAAA, and TXT records using Unbound's Host Overrides. A/AAAA/TXT records work because they effectively map 1:1 with Host Overrides.
 
-With significantly more effort, CNAMEs could be supported and mapped to Host Override Aliases, which may be implemented in the future.
+CNAME records are supported using Unbound's Host Override Aliases.
 
 > [!NOTE]
 > TXT record support requires OPNsense >= 25.7 or later versions with TXT record support in Unbound.

--- a/internal/opnsense-unbound/client.go
+++ b/internal/opnsense-unbound/client.go
@@ -137,6 +137,29 @@ func (c *httpClient) GetHostOverrides() ([]DNSRecord, error) {
 	return records.Rows, nil
 }
 
+// GetHostAliases retrieves the list of HostAliases from the Opnsense Firewall's Unbound API.
+// These are equivalent to CNAME records
+func (c *httpClient) GetHostAliases() ([]DNSAlias, error) {
+	resp, err := c.doRequest(
+		http.MethodGet,
+		"settings/searchHostAlias",
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var aliases unboundAliasesList
+	if err = json.NewDecoder(resp.Body).Decode(&aliases); err != nil {
+		return nil, err
+	}
+
+	log.Debugf("getaliases: retrieved aliases: %+v", aliases.Rows)
+
+	return aliases.Rows, nil
+}
+
 // CreateHostOverride creates a new DNS A, AAAA, or TXT record in the Opnsense Firewall's Unbound API.
 func (c *httpClient) CreateHostOverride(endpoint *endpoint.Endpoint) (*DNSRecord, error) {
 	log.Debugf("create: Try pulling pre-existing Unbound %s record: %s", endpoint.RecordType, endpoint.DNSName)
@@ -197,6 +220,63 @@ func (c *httpClient) CreateHostOverride(endpoint *endpoint.Endpoint) (*DNSRecord
 	return nil, nil
 }
 
+// CreateHostAlias creates a new DNS CNAME record in the Opnsense Firewall's Unbound API.
+func (c *httpClient) CreateHostAlias(endpoint *endpoint.Endpoint) (*DNSAlias, error) {
+	log.Debugf("create: Try pulling pre-existing Unbound CNAME record: %s", endpoint.DNSName)
+	lookup, err := c.lookupHostAliasIdentifier(endpoint.DNSName)
+	if err != nil {
+		return nil, err
+	}
+
+	if lookup != nil {
+		log.Debugf("create: Found uuid: %s", lookup.Uuid)
+		log.Debugf("create: Found existing CNAME record for %s : %s", endpoint.DNSName, lookup.Uuid)
+		return lookup, nil
+	}
+
+	// For CNAME, we need to find the target host override first
+	targetHost := endpoint.Targets[0]
+	targetOverride, err := c.lookupHostOverrideIdentifier(targetHost, "A")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find target host override for %s: %w", targetHost, err)
+	}
+	if targetOverride == nil {
+		return nil, fmt.Errorf("target host override not found for %s", targetHost)
+	}
+
+	splitHost := SplitUnboundFQDN(endpoint.DNSName)
+
+	jsonBody, err := json.Marshal(unboundAddHostAlias{
+		Alias: DNSAlias{
+			Enabled:  "1",
+			Host:     targetOverride.Uuid,
+			Hostname:    splitHost[0],
+			Domain:   splitHost[1],
+		}})
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debugf("create: POST CNAME: %s", string(jsonBody))
+	resp, err := c.doRequest(
+		http.MethodPost,
+		"settings/addHostAlias",
+		bytes.NewReader(jsonBody),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var alias unboundAddHostAlias
+	if err = json.NewDecoder(resp.Body).Decode(&alias); err != nil {
+		return nil, err
+	}
+	log.Debugf("create: created alias: %+v", alias)
+
+	return nil, nil
+}
+
 // DeleteHostOverride deletes a DNS record from the Opnsense Firewall's Unbound API.
 func (c *httpClient) DeleteHostOverride(endpoint *endpoint.Endpoint) error {
 	log.Debugf("delete: Deleting record %+v", endpoint)
@@ -221,6 +301,33 @@ func (c *httpClient) DeleteHostOverride(endpoint *endpoint.Endpoint) error {
 	return nil
 }
 
+// DeleteHostAlias deletes a DNS CNAME record from the Opnsense Firewall's Unbound API.
+func (c *httpClient) DeleteHostAlias(endpoint *endpoint.Endpoint) error {
+	log.Debugf("delete: Deleting CNAME record %+v", endpoint)
+	lookup, err := c.lookupHostAliasIdentifier(endpoint.DNSName)
+	if err != nil {
+		return err
+	}
+
+	if lookup == nil {
+		log.Debugf("delete: CNAME record not found for %s", endpoint.DNSName)
+		return nil
+	}
+
+	log.Debugf("delete: Found CNAME match %s", lookup.Uuid)
+
+	log.Debugf("delete: Sending POST CNAME %s", lookup.Uuid)
+	if _, err = c.doRequest(
+		http.MethodPost,
+		path.Join("settings/delHostAlias", lookup.Uuid),
+		strings.NewReader(emptyJSONObject),
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // lookupHostOverrideIdentifier finds a HostOverride in the Opnsense Firewall's Unbound API.
 func (c *httpClient) lookupHostOverrideIdentifier(key, recordType string) (*DNSRecord, error) {
 	records, err := c.GetHostOverrides()
@@ -238,6 +345,26 @@ func (c *httpClient) lookupHostOverrideIdentifier(key, recordType string) (*DNSR
 		}
 	}
 	log.Debugf("lookup: No matching record found for Host=%s, Domain=%s, Type=%s", splitHost[0], splitHost[1], EmbellishUnboundType(recordType))
+	return nil, nil
+}
+
+// lookupHostAliasIdentifier finds a HostAlias in the Opnsense Firewall's Unbound API.
+func (c *httpClient) lookupHostAliasIdentifier(key string) (*DNSAlias, error) {
+	aliases, err := c.GetHostAliases()
+	if err != nil {
+		return nil, err
+	}
+	log.Debug("lookup: Splitting FQDN for alias")
+	splitHost := SplitUnboundFQDN(key)
+
+	for _, a := range aliases {
+		log.Debugf("lookup: Checking alias: Alias=%s, Domain=%s, UUID=%s", a.Hostname, a.Domain, a.Uuid)
+		if a.Hostname == splitHost[0] && a.Domain == splitHost[1] {
+			log.Debugf("lookup: Alias UUID Match Found: %s", a.Uuid)
+			return &a, nil
+		}
+	}
+	log.Debugf("lookup: No matching alias found for Alias=%s, Domain=%s", splitHost[0], splitHost[1])
 	return nil, nil
 }
 

--- a/internal/opnsense-unbound/provider.go
+++ b/internal/opnsense-unbound/provider.go
@@ -34,7 +34,7 @@ func NewOpnsenseProvider(domainFilter endpoint.DomainFilter, config *Config) (pr
 	return p, nil
 }
 
-// Records returns the list of HostOverride records in Opnsense Unbound.
+// Records returns the list of HostOverride and HostAlias records in Opnsense Unbound.
 func (p *Provider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	log.Debugf("records: retrieving records from opnsense")
 
@@ -43,6 +43,12 @@ func (p *Provider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 		return nil, err
 	}
 
+	aliases, err := p.client.GetHostAliases()
+	if err != nil {
+		return nil, err
+	}
+
+	// Process A/AAAA/TXT records
 	var endpoints []*endpoint.Endpoint
 	for _, record := range records {
 		var targets endpoint.Targets
@@ -67,6 +73,32 @@ func (p *Provider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 		endpoints = append(endpoints, ep)
 	}
 
+	// Process CNAME records (aliases)
+	for _, alias := range aliases {
+		// Find the target host override to get the target DNS name
+		targetRecord, err := p.findHostOverrideByUUID(alias.Host)
+		if err != nil {
+			log.Debugf("records: failed to find target host for alias %s: %v", alias.Uuid, err)
+			continue
+		}
+		if targetRecord == nil {
+			log.Debugf("records: target host not found for alias %s", alias.Uuid)
+			continue
+		}
+
+		ep := &endpoint.Endpoint{
+			DNSName:    JoinUnboundFQDN(alias.Hostname, alias.Domain),
+			RecordType: "CNAME",
+			Targets:    endpoint.NewTargets(JoinUnboundFQDN(targetRecord.Hostname, targetRecord.Domain)),
+		}
+
+		if !p.domainFilter.Match(ep.DNSName) {
+			continue
+		}
+
+		endpoints = append(endpoints, ep)
+	}
+
 	log.Debugf("records: retrieved: %+v", endpoints)
 
 	return endpoints, nil
@@ -75,13 +107,31 @@ func (p *Provider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 // ApplyChanges applies a given set of changes in the DNS provider.
 func (p *Provider) ApplyChanges(ctx context.Context, changes *plan.Changes) error {
 	for _, endpoint := range append(changes.UpdateOld, changes.Delete...) {
-		if err := p.client.DeleteHostOverride(endpoint); err != nil {
+		if endpoint.RecordType == "CNAME" {
+			if err := p.client.DeleteHostAlias(endpoint); err != nil {
+				return err
+			}
+		} else {
+			if err := p.client.DeleteHostOverride(endpoint); err != nil {
+				return err
+			}
+		}
+	}
+	var isCNAME map[bool][]*endpoint.Endpoint = make(map[bool][]*endpoint.Endpoint)
+
+	for _, endpoint := range append(changes.Create, changes.UpdateNew...) {
+		isCNAME[endpoint.RecordType == "CNAME"] = append(isCNAME[endpoint.RecordType == "CNAME"], endpoint)
+	}
+
+	// It is important to apply the CNAME changes after the overrides have been applied
+	// if not, validation will fail when trying to create an alias without a valid hostname
+	for _, endpoint := range isCNAME[false] {
+		if _, err := p.client.CreateHostOverride(endpoint); err != nil {
 			return err
 		}
 	}
-
-	for _, endpoint := range append(changes.Create, changes.UpdateNew...) {
-		if _, err := p.client.CreateHostOverride(endpoint); err != nil {
+	for _, endpoint := range isCNAME[true] {
+		if _, err := p.client.CreateHostAlias(endpoint); err != nil {
 			return err
 		}
 	}
@@ -94,4 +144,20 @@ func (p *Provider) ApplyChanges(ctx context.Context, changes *plan.Changes) erro
 // GetDomainFilter returns the domain filter for the provider.
 func (p *Provider) GetDomainFilter() endpoint.DomainFilter {
 	return p.domainFilter
+}
+
+// findHostOverrideByUUID finds a host override by its UUID.
+func (p *Provider) findHostOverrideByUUID(uuid string) (*DNSRecord, error) {
+	records, err := p.client.GetHostOverrides()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, record := range records {
+		if record.Uuid == uuid {
+			return &record, nil
+		}
+	}
+
+	return nil, nil
 }

--- a/internal/opnsense-unbound/types.go
+++ b/internal/opnsense-unbound/types.go
@@ -22,6 +22,17 @@ type DNSRecord struct {
 	TxtData     string `json:"txtdata,omitempty"`
 }
 
+// DNSAlias represents a DNS alias (CNAME) record in the Opnsense Unbound API.
+type DNSAlias struct {
+	Uuid        string `json:"uuid"`
+	Enabled     string `json:"enabled"`
+	Hostname    string `json:"hostname"`
+	Domain      string `json:"domain"`
+	Host        string `json:"host"` // Points to the host override UUID
+	Override    string `json:"%host"` // this is just used for debugging
+	Description string `json:"description"`
+}
+
 // unboundRecordsList is the main item returned from the Opnsense Unbound API
 // since it has some decorators we just throw this struct away
 type unboundRecordsList struct {
@@ -31,7 +42,20 @@ type unboundRecordsList struct {
 	Rows     []DNSRecord `json:"Rows"`
 }
 
+// unboundAliasesList is the main item returned from the Opnsense Unbound API for aliases
+type unboundAliasesList struct {
+	RowCount int        `json:"rowCount"`
+	Total    int        `json:"total"`
+	Current  int        `json:"current"`
+	Rows     []DNSAlias `json:"Rows"`
+}
+
 // Specific format for POST against the Opnsense Unbound API
 type unboundAddHostOverride struct {
 	Host DNSRecord `json:"host"`
+}
+
+// Specific format for POST against the Opnsense Unbound API for aliases
+type unboundAddHostAlias struct {
+	Alias DNSAlias `json:"alias"`
 }

--- a/internal/opnsense-unbound/utils.go
+++ b/internal/opnsense-unbound/utils.go
@@ -30,6 +30,8 @@ func EmbellishUnboundType(unboundType string) string {
 		return unboundType + " (IPv6 address)"
 	case "TXT":
 		return unboundType + " (Text record)"
+	case "CNAME":
+		return unboundType + " (CNAME record)"
 	}
 	return unboundType
 }


### PR DESCRIPTION
Adds CNAME record support by mapping lifecycle request to Unbound Host Aliases.

Tested on both k8s' Ingress and traefik's IngressRoute CRDs by adding the annotation of `external-dns.alpha.kubernetes.io/target: <<host override FQDN>>` to an ingress route.

This requires having a preexisting A record created by the `external-dns.alpha.kubernetes.io/hostname: <<host override FQDN>>` annotation on another service in your cluster.

Closes https://github.com/crutonjohn/external-dns-opnsense-webhook/issues/2
