### PR TITLE
feat: add per-endpoint PTR control

### DIFF
--- a/internal/opnsense-unbound/client.go
+++ b/internal/opnsense-unbound/client.go
@@ -165,6 +165,7 @@ func (c *httpClient) CreateHostOverride(endpoint *endpoint.Endpoint) (*DNSRecord
 	} else {
 		record.Server = endpoint.Targets[0]
 	}
+	ApplyAddPtrToRecord(&record, endpoint)
 
 	jsonBody, err := json.Marshal(unboundAddHostOverride{
 		Host: record,

--- a/internal/opnsense-unbound/provider.go
+++ b/internal/opnsense-unbound/provider.go
@@ -59,6 +59,9 @@ func (p *Provider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 			RecordType: recordType,
 			Targets:    targets,
 		}
+		if (recordType == "A" || recordType == "AAAA") && record.AddPtr == "0" {
+			ep.SetProviderSpecificProperty(ProviderSpecificAddPtrKey, "0")
+		}
 
 		if !p.domainFilter.Match(ep.DNSName) {
 			continue

--- a/internal/opnsense-unbound/types.go
+++ b/internal/opnsense-unbound/types.go
@@ -20,6 +20,7 @@ type DNSRecord struct {
 	Mx          string `json:"mx,omitempty"`
 	MxPrio      string `json:"mxprio,omitempty"`
 	TxtData     string `json:"txtdata,omitempty"`
+	AddPtr      string `json:"addptr,omitempty"`
 }
 
 // unboundRecordsList is the main item returned from the Opnsense Unbound API

--- a/internal/opnsense-unbound/utils.go
+++ b/internal/opnsense-unbound/utils.go
@@ -1,6 +1,33 @@
 package opnsense
 
-import "strings"
+import (
+	"strings"
+
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+const ProviderSpecificAddPtrKey = "opnsense/addptr"
+
+// Sets AddPtr on record for A/AAAA only when opnsense/addptr is exactly "0" or "1".
+// Otherwise left blank.
+func ApplyAddPtrToRecord(record *DNSRecord, ep *endpoint.Endpoint) {
+	if ep.RecordType != "A" && ep.RecordType != "AAAA" {
+		return
+	}
+	v, ok := ep.GetProviderSpecificProperty(ProviderSpecificAddPtrKey)
+	if !ok {
+		return
+	}
+	s := strings.TrimSpace(v)
+	switch s {
+	case "0":
+		record.AddPtr = "0"
+	case "1":
+		record.AddPtr = "1"
+	default:
+		return
+	}
+}
 
 // UnboundFQDNSplitter splits a DNSName into two parts,
 // [0] Being the top level hostname

--- a/internal/opnsense-unbound/utils_test.go
+++ b/internal/opnsense-unbound/utils_test.go
@@ -1,0 +1,108 @@
+package opnsense
+
+import (
+	"encoding/json"
+	"testing"
+
+	"sigs.k8s.io/external-dns/endpoint"
+)
+
+func TestApplyAddPtrToRecord(t *testing.T) {
+	t.Parallel()
+	newA := func() *endpoint.Endpoint {
+		return endpoint.NewEndpoint("foo.bar.com", "A", "192.168.99.216")
+	}
+
+	var rec DNSRecord
+	ApplyAddPtrToRecord(&rec, newA())
+	if rec.AddPtr != "" {
+		t.Errorf("no providerSpecific: want AddPtr omitted (empty), got %q", rec.AddPtr)
+	}
+
+	rec = DNSRecord{}
+	ep := newA()
+	ep.SetProviderSpecificProperty(ProviderSpecificAddPtrKey, "0")
+	ApplyAddPtrToRecord(&rec, ep)
+	if rec.AddPtr != "0" {
+		t.Errorf("explicit 0: want 0, got %q", rec.AddPtr)
+	}
+
+	rec = DNSRecord{}
+	ep1 := newA()
+	ep1.SetProviderSpecificProperty(ProviderSpecificAddPtrKey, "1")
+	ApplyAddPtrToRecord(&rec, ep1)
+	if rec.AddPtr != "1" {
+		t.Errorf("explicit 1: want 1, got %q", rec.AddPtr)
+	}
+
+	rec = DNSRecord{}
+	epTxt := endpoint.NewEndpoint("foo.bar.com", "TXT", "text")
+	epTxt.SetProviderSpecificProperty(ProviderSpecificAddPtrKey, "1")
+	ApplyAddPtrToRecord(&rec, epTxt)
+	if rec.AddPtr != "" {
+		t.Errorf("TXT: opnsense/addptr ignored, want AddPtr empty, got %q", rec.AddPtr)
+	}
+
+	rec = DNSRecord{}
+	epAAAA := endpoint.NewEndpoint("foo.bar.com", "AAAA", "2001:db8::1")
+	epAAAA.SetProviderSpecificProperty(ProviderSpecificAddPtrKey, "0")
+	ApplyAddPtrToRecord(&rec, epAAAA)
+	if rec.AddPtr != "0" {
+		t.Errorf("AAAA explicit 0: want 0, got %q", rec.AddPtr)
+	}
+}
+
+func TestDNSRecordJSONIncludesAddptrWhenSet(t *testing.T) {
+	t.Parallel()
+	body, err := json.Marshal(unboundAddHostOverride{
+		Host: DNSRecord{
+			Enabled:  "1",
+			Rr:       "A",
+			Hostname: "app",
+			Domain:   "example.com",
+			Server:   "10.0.0.1",
+			AddPtr:   "0",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatal(err)
+	}
+	host, ok := m["host"].(map[string]any)
+	if !ok {
+		t.Fatalf("host: %#v", m["host"])
+	}
+	if host["addptr"] != "0" {
+		t.Fatalf("addptr: want \"0\", got %#v", host["addptr"])
+	}
+}
+
+func TestDNSRecordJSONOmitsAddptrWhenEmpty(t *testing.T) {
+	t.Parallel()
+	body, err := json.Marshal(unboundAddHostOverride{
+		Host: DNSRecord{
+			Enabled:  "1",
+			Rr:       "A",
+			Hostname: "app",
+			Domain:   "example.com",
+			Server:   "10.0.0.1",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatal(err)
+	}
+	host, ok := m["host"].(map[string]any)
+	if !ok {
+		t.Fatalf("host: %#v", m["host"])
+	}
+	if _, has := host["addptr"]; has {
+		t.Fatalf("addptr should be omitted, host=%#v", host)
+	}
+}


### PR DESCRIPTION
By default OPNSense would enable the "Add PTR record" setting on host overrides. This PR adds a providerSpecific setting to disable it.

eg:
```
  endpoints:
    - dnsName: foo.bar.com
      recordTTL: 120
      recordType: A
      targets:
        - 192.168.99.216
      providerSpecific:
        - name: opnsense/addptr
          value: "0"
```

Tested on my own deployment.